### PR TITLE
菜单为一级目录会导致路径错误返回

### DIFF
--- a/twelvet-server/twelvet-server-system/src/main/java/com/twelvet/server/system/service/impl/SysMenuServiceImpl.java
+++ b/twelvet-server/twelvet-server-system/src/main/java/com/twelvet/server/system/service/impl/SysMenuServiceImpl.java
@@ -258,12 +258,7 @@ public class SysMenuServiceImpl implements ISysMenuService {
 	 * @return 路由名称
 	 */
 	private String getRouteName(SysMenu menu) {
-		String routerName = menu.getPath();
-		// 非外链并且是一级目录（类型为目录）
-		if (isMenuFrame(menu)) {
-			routerName = StringUtils.EMPTY;
-		}
-		return routerName;
+		return menu.getPath();
 	}
 
 	/**


### PR DESCRIPTION
修正菜单为一级目录的错误路径